### PR TITLE
Hold the reference to scrollView until we remove our observer

### DIFF
--- a/PullToRefreshView.h
+++ b/PullToRefreshView.h
@@ -46,7 +46,7 @@ typedef enum {
 	UIActivityIndicatorView *activityView;
 }
 
-@property (nonatomic, weak) UIScrollView *scrollView;
+@property (nonatomic, strong) UIScrollView *scrollView;
 @property (nonatomic, weak) id<PullToRefreshViewDelegate> delegate;
 
 - (void)refreshLastUpdatedDate;

--- a/PullToRefreshView.m
+++ b/PullToRefreshView.m
@@ -205,6 +205,7 @@
 
 - (void)dealloc {
 	[scrollView removeObserver:self forKeyPath:@"contentOffset"];
+	scrollView = nil;
 }
 
 @end


### PR DESCRIPTION
I was running into a similar problem to the one described here:
   https://github.com/sonnyparlin/PullToRefresh/issues/1
It seemed cleaner to switch to a strong reference so the scrollView
sticks around until we're done with it then we can let it deallocate.
