### PR TITLE
Added 'enabled' property

### DIFF
--- a/PullToRefreshView.h
+++ b/PullToRefreshView.h
@@ -48,6 +48,7 @@ typedef enum {
 
 @property (nonatomic, strong) UIScrollView *scrollView;
 @property (nonatomic, weak) id<PullToRefreshViewDelegate> delegate;
+@property (nonatomic, assign, getter = isEnabled) BOOL enabled;
 
 - (void)refreshLastUpdatedDate;
 - (void)finishedLoading;

--- a/PullToRefreshView.m
+++ b/PullToRefreshView.m
@@ -112,6 +112,19 @@
 #pragma mark -
 #pragma mark Setters
 
+- (void)setEnabled:(BOOL)enabled
+{
+	if (enabled == _enabled)
+		return;
+	
+	_enabled = enabled;
+	[UIView animateWithDuration:0.25
+									 animations:
+	 ^{
+		 self.alpha = enabled ? 1 : 0;
+	 }];
+}
+
 - (void)refreshLastUpdatedDate {
     NSDate *date = [NSDate date];
     
@@ -160,7 +173,7 @@
 #pragma mark UIScrollView
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
-    if ([keyPath isEqualToString:@"contentOffset"]) {
+    if ([keyPath isEqualToString:@"contentOffset"] && self.isEnabled) {
         if (scrollView.isDragging) {
             if (state == PullToRefreshViewStateReady) {
                 if (scrollView.contentOffset.y > -65.0f && scrollView.contentOffset.y < 0.0f) 

--- a/PullToRefreshView.m
+++ b/PullToRefreshView.m
@@ -106,7 +106,8 @@
         activityView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
 		activityView.frame = CGRectMake(10.0f, frame.size.height - 38.0f, 20.0f, 20.0f);
 		[self addSubview:activityView];
-        
+		
+			self.enabled = YES;
 		[self setState:PullToRefreshViewStateNormal];
     }
     


### PR DESCRIPTION
I've added a property called 'enabled' to the PullToRefresh control. If it's not enabled, it's made invisible and the KVO observation of the contentOffset is temporarily disabled.
