### PR TITLE
Fixed bug with the view not coming back down

### DIFF
--- a/PullToRefreshView.m
+++ b/PullToRefreshView.m
@@ -169,8 +169,8 @@
 			[self showActivity:NO animated:NO];
             [self setImageFlipped:NO];
 			[self refreshLastUpdatedDate];
-			break;
             scrollView.contentInset = self.startingContentInset;
+			break;
             
 		case PullToRefreshViewStateLoading:
 			statusLabel.text = @"Loading...";


### PR DESCRIPTION
For some reason, this statement was after the break, and it wasn't
being called.
